### PR TITLE
Fix build warnings with Xcode 14.0

### DIFF
--- a/Sources/Starscream/Compression.swift
+++ b/Sources/Starscream/Compression.swift
@@ -80,10 +80,12 @@ class Decompressor {
         strm.avail_in = CUnsignedInt(count)
 
         repeat {
-            strm.next_out = UnsafeMutablePointer<UInt8>(&buffer)
-            strm.avail_out = CUnsignedInt(buffer.count)
+            buffer.withUnsafeMutableBytes { (bufferPtr) in
+                strm.next_out = bufferPtr.bindMemory(to: UInt8.self).baseAddress
+                strm.avail_out = CUnsignedInt(bufferPtr.count)
 
-            res = inflate(&strm, 0)
+                res = inflate(&strm, 0)
+            }
 
             let byteCount = buffer.count - Int(strm.avail_out)
             out.append(buffer, count: byteCount)
@@ -142,10 +144,12 @@ class Compressor {
             strm.avail_in = CUnsignedInt(data.count)
 
             repeat {
-                strm.next_out = UnsafeMutablePointer<UInt8>(&buffer)
-                strm.avail_out = CUnsignedInt(buffer.count)
+                buffer.withUnsafeMutableBytes { (bufferPtr) in
+                    strm.next_out = bufferPtr.bindMemory(to: UInt8.self).baseAddress
+                    strm.avail_out = CUnsignedInt(bufferPtr.count)
 
-                res = deflate(&strm, Z_SYNC_FLUSH)
+                    res = deflate(&strm, Z_SYNC_FLUSH)
+                }
 
                 let byteCount = buffer.count - Int(strm.avail_out)
                 compressed.append(buffer, count: byteCount)

--- a/Sources/Starscream/Data+Extensions.swift
+++ b/Sources/Starscream/Data+Extensions.swift
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Data+Extensions.swift
+//  Starscream
+//
+//  Created by Dalton Cherry on 3/27/19.
+//  Copyright © 2019 Vluxe. All rights reserved.
+//
+//  Fix for deprecation warnings
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+import Foundation
+
+internal extension Data {
+    struct ByteError: Swift.Error {}
+    
+    #if swift(>=5.0)
+    func withUnsafeBytes<ResultType, ContentType>(_ completion: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
+        return try withUnsafeBytes {
+            if let baseAddress = $0.baseAddress, $0.count > 0 {
+                return try completion(baseAddress.assumingMemoryBound(to: ContentType.self))
+            } else {
+                throw ByteError()
+            }
+        }
+    }
+    #endif
+    
+    #if swift(>=5.0)
+    mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ completion: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
+        return try withUnsafeMutableBytes {
+            if let baseAddress = $0.baseAddress, $0.count > 0 {
+                return try completion(baseAddress.assumingMemoryBound(to: ContentType.self))
+            } else {
+                throw ByteError()
+            }
+        }
+    }
+    #endif
+}

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -58,7 +58,7 @@ public struct WSError: Error {
 }
 
 //WebSocketClient is setup to be dependency injection for testing
-public protocol WebSocketClient: class {
+public protocol WebSocketClient: AnyObject {
     var delegate: WebSocketDelegate? {get set}
     var pongDelegate: WebSocketPongDelegate? {get set}
     var disableSSLCertValidation: Bool {get set}
@@ -116,7 +116,7 @@ public struct SSLSettings {
     #endif
 }
 
-public protocol WSStreamDelegate: class {
+public protocol WSStreamDelegate: AnyObject {
     func newBytesInStream()
     func streamDidError(error: Error?)
 }
@@ -310,7 +310,7 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
 //WebSocket implementation
 
 //standard delegate you should use
-public protocol WebSocketDelegate: class {
+public protocol WebSocketDelegate: AnyObject {
     func websocketDidConnect(socket: WebSocketClient)
     func websocketDidDisconnect(socket: WebSocketClient, error: Error?)
     func websocketDidReceiveMessage(socket: WebSocketClient, text: String)
@@ -318,12 +318,12 @@ public protocol WebSocketDelegate: class {
 }
 
 //got pongs
-public protocol WebSocketPongDelegate: class {
+public protocol WebSocketPongDelegate: AnyObject {
     func websocketDidReceivePong(socket: WebSocketClient, data: Data?)
 }
 
 // A Delegate with more advanced info on messages and connection etc.
-public protocol WebSocketAdvancedDelegate: class {
+public protocol WebSocketAdvancedDelegate: AnyObject {
     func websocketDidConnect(socket: WebSocket)
     func websocketDidDisconnect(socket: WebSocket, error: Error?)
     func websocketDidReceiveMessage(socket: WebSocket, text: String, response: WebSocket.WSResponse)
@@ -1324,7 +1324,7 @@ private extension String {
         let data = self.data(using: String.Encoding.utf8)!
         var digest = [UInt8](repeating: 0, count:Int(CC_SHA1_DIGEST_LENGTH))
         data.withUnsafeBytes { _ = CC_SHA1($0, CC_LONG(data.count), &digest) }
-        return Data(bytes: digest).base64EncodedString()
+        return Data(digest).base64EncodedString()
     }
 }
 

--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		33CCF08A1F5DDC030099B092 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D88EAF811ED4DFD3004FE2C3 /* libz.tbd */; };
 		33CCF08C1F5DDC030099B092 /* Starscream.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1360001C473BEF00AA3A01 /* Starscream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48F1584221FBC1200093F06A /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CCF0921F5DDC030099B092 /* Starscream.framework */; };
+		8BFC205328D4C4A30081E84C /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFC205228D4C4A30081E84C /* Data+Extensions.swift */; };
+		8BFC205428D4CA880081E84C /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFC205228D4C4A30081E84C /* Data+Extensions.swift */; };
 		BBB5ABE5215E2217005B48B6 /* Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5ABE1215E2217005B48B6 /* Compression.swift */; };
 		BBB5ABE6215E2217005B48B6 /* SSLClientCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5ABE2215E2217005B48B6 /* SSLClientCertificate.swift */; };
 		BBB5ABE7215E2217005B48B6 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5ABE3215E2217005B48B6 /* SSLSecurity.swift */; };
@@ -26,6 +28,7 @@
 		5C13600C1C473BFE00AA3A01 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = SOURCE_ROOT; };
 		6B3E7A0019D48C2F006071F7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		742419BB1DC6BDBA003ACE43 /* StarscreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StarscreamTests.swift; path = StarscreamTests/StarscreamTests.swift; sourceTree = "<group>"; };
+		8BFC205228D4C4A30081E84C /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Data+Extensions.swift"; path = "Starscream/Data+Extensions.swift"; sourceTree = "<group>"; };
 		BBB5ABE1215E2217005B48B6 /* Compression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Compression.swift; path = Starscream/Compression.swift; sourceTree = "<group>"; };
 		BBB5ABE2215E2217005B48B6 /* SSLClientCertificate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SSLClientCertificate.swift; path = Starscream/SSLClientCertificate.swift; sourceTree = "<group>"; };
 		BBB5ABE3215E2217005B48B6 /* SSLSecurity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Starscream/SSLSecurity.swift; sourceTree = "<group>"; };
@@ -81,6 +84,7 @@
 				BBB5ABE2215E2217005B48B6 /* SSLClientCertificate.swift */,
 				BBB5ABE3215E2217005B48B6 /* SSLSecurity.swift */,
 				BBB5ABE4215E2217005B48B6 /* WebSocket.swift */,
+				8BFC205228D4C4A30081E84C /* Data+Extensions.swift */,
 				5C1360001C473BEF00AA3A01 /* Starscream.h */,
 				6B3E79E919D48B7F006071F7 /* Supporting Files */,
 			);
@@ -170,7 +174,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = Vluxe;
 				TargetAttributes = {
 					335FA1F41F5DF71D00F6D2EC = {
@@ -183,11 +187,11 @@
 			};
 			buildConfigurationList = 6B3E79E019D48B7F006071F7 /* Build configuration list for PBXProject "Starscream" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 6B3E79DC19D48B7F006071F7;
 			productRefGroup = 6B3E79E719D48B7F006071F7 /* Products */;
@@ -222,6 +226,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BFC205428D4CA880081E84C /* Data+Extensions.swift in Sources */,
 				335FA1F91F5DF71D00F6D2EC /* CompressionTests.swift in Sources */,
 				335FA1FA1F5DF71D00F6D2EC /* StarscreamTests.swift in Sources */,
 			);
@@ -235,6 +240,7 @@
 				BBB5ABE8215E2217005B48B6 /* WebSocket.swift in Sources */,
 				BBB5ABE7215E2217005B48B6 /* SSLSecurity.swift in Sources */,
 				BBB5ABE6215E2217005B48B6 /* SSLClientCertificate.swift in Sources */,
+				8BFC205328D4C4A30081E84C /* Data+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Starscream.xcodeproj/xcshareddata/xcschemes/Starscream.xcscheme
+++ b/Starscream.xcodeproj/xcshareddata/xcschemes/Starscream.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1400"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "33CCF0841F5DDC030099B092"
+            BuildableName = "Starscream.framework"
+            BlueprintName = "Starscream"
+            ReferencedContainer = "container:Starscream.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -44,17 +53,6 @@
             </LocationScenarioReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "33CCF0841F5DDC030099B092"
-            BuildableName = "Starscream.framework"
-            BlueprintName = "Starscream"
-            ReferencedContainer = "container:Starscream.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -75,8 +73,6 @@
             ReferencedContainer = "container:Starscream.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This PR fixes build warnings that show up in Xcode 14.0.

"Data+Extensions" helper is copied from the [original repository](https://github.com/daltoniam/Starscream/blob/master/Sources/DataBytes/Data%2BExtensions.swift).